### PR TITLE
5.3.x: Error 500 Problem reading task from guvnor

### DIFF
--- a/jbpm-form-builder-distribution/pom.xml
+++ b/jbpm-form-builder-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-form-builder-parent</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0.Final</version>
   </parent>
 
   <artifactId>jbpm-form-builder-distribution</artifactId>

--- a/jbpm-gwt-form-api/pom.xml
+++ b/jbpm-gwt-form-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jbpm-form-builder-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0.Final</version>
   </parent>
   
   <artifactId>jbpm-gwt-form-api</artifactId>

--- a/jbpm-gwt-form-builder/pom.xml
+++ b/jbpm-gwt-form-builder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jbpm-form-builder-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0.Final</version>
   </parent>
   
   <artifactId>jbpm-gwt-form-builder</artifactId>

--- a/jbpm-gwt-form-builder/src/main/java/org/jbpm/formbuilder/server/xml/PackageListDTO.java
+++ b/jbpm-gwt-form-builder/src/main/java/org/jbpm/formbuilder/server/xml/PackageListDTO.java
@@ -21,7 +21,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlRootElement(name = "packages")
+@XmlRootElement(name = "collection")
 public class PackageListDTO {
     
     public static final Class<?>[] RELATED_CLASSES = new Class<?>[] { PackageListDTO.class, PackageDTO.class, MetaDataDTO.class };

--- a/jbpm-gwt-form-builder/src/test/java/org/jbpm/formbuilder/server/form/GuvnorFormDefinitionServiceTest.java
+++ b/jbpm-gwt-form-builder/src/test/java/org/jbpm/formbuilder/server/form/GuvnorFormDefinitionServiceTest.java
@@ -497,11 +497,11 @@ public class GuvnorFormDefinitionServiceTest extends TestCase {
         HttpClient client = EasyMock.createMock(HttpClient.class);
         String uuid = UUID.randomUUID().toString();
         Map<String, String> responses1 = new HashMap<String, String>();
-        String xml1 = "<packages><package>" +
+        String xml1 = "<collection><package>" +
                 "<title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/asset1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/asset2</assets>" +
-                "</package></packages>";
+                "</package></collection>";
         String xml2 = "<asset>" +
                 "<sourceLink>" + helper.getRestBaseUrl() + "somePackage/asset1/source</sourceLink>" +
                 "<metadata>" +
@@ -541,11 +541,11 @@ public class GuvnorFormDefinitionServiceTest extends TestCase {
         HttpClient client = EasyMock.createMock(HttpClient.class);
         String uuid = UUID.randomUUID().toString();
         Map<String, String> responses1 = new HashMap<String, String>();
-        String xml1 = "<packages><package>" +
+        String xml1 = "<collection><package>" +
                 "<title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/asset1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/asset2</assets>" +
-                "</package></packages>";
+                "</package></collection>";
         String xml2 = "<asset>" +
                 "<sourceLink>" + helper.getRestBaseUrl() + "somePackage/asset1/source</sourceLink>" +
                 "<metadata>" +

--- a/jbpm-gwt-form-builder/src/test/java/org/jbpm/formbuilder/server/task/GuvnorTaskDefinitionServiceTest.java
+++ b/jbpm-gwt-form-builder/src/test/java/org/jbpm/formbuilder/server/task/GuvnorTaskDefinitionServiceTest.java
@@ -176,10 +176,10 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess2</assets>" +
-                "</package></packages>";
+                "</package></collection>";
         String xml2 = "<asset><sourceLink>" +
                 helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1/source" +
                 "</sourceLink><metadata><format>bpmn2</format></metadata></asset>";
@@ -219,7 +219,7 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assetsBROKEN_XML>";
         responses.put("GET " + helper.getRestBaseUrl(), xml1);
         EasyMock.expect(client.executeMethod(EasyMock.isA(MockGetMethod.class))).
@@ -289,11 +289,11 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess2</assets>" +
                 "<metadata><uuid>" + uuid1 + "</uuid></metadata>" +
-                "</package></packages>";
+                "</package></collection>";
         String xml2 = "<asset><sourceLink>" +
                 helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1/source" +
                 "</sourceLink><metadata><format>bpmn2</format><uuid>somethingelse</uuid></metadata></asset>";
@@ -320,7 +320,7 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assetsBROKEN_XML>";
         responses.put("GET " + helper.getRestBaseUrl(), xml1);
         EasyMock.expect(client.executeMethod(EasyMock.isA(MockGetMethod.class))).
@@ -383,10 +383,10 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess2</assets>" +
-                "</package></packages>";
+                "</package></collection>";
         String xml2 = "<asset><sourceLink>" +
                 helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1/source" +
                 "</sourceLink><metadata><format>bpmn2</format><uuid>somethingelse</uuid></metadata></asset>";
@@ -420,7 +420,7 @@ public class GuvnorTaskDefinitionServiceTest extends TestCase {
         GuvnorTaskDefinitionService service = createService(baseUrl, "", "");
         HttpClient client = EasyMock.createMock(HttpClient.class);
         Map<String, String> responses = new HashMap<String, String>();
-        String xml1 = "<packages><package><title>somePackage</title>" +
+        String xml1 = "<collection><package><title>somePackage</title>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess1</assets>" +
                 "<assets>" + helper.getRestBaseUrl() + "somePackage/assets/sampleProcess2</assetsBROKEN_XML>";
         responses.put("GET " + helper.getRestBaseUrl(), xml1);

--- a/jbpm-gwt-form-exporter-freemarker/pom.xml
+++ b/jbpm-gwt-form-exporter-freemarker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jbpm-form-builder-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0.Final</version>
   </parent>
   
   <artifactId>jbpm-gwt-form-exporter-freemarker</artifactId>

--- a/jbpm-gwt-form-exporter-gwt/pom.xml
+++ b/jbpm-gwt-form-exporter-gwt/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>jbpm-form-builder-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0.Final</version>
   </parent>
   
   <artifactId>jbpm-gwt-form-exporter-gwt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-parent</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.4.0.Final</version>
     <!-- relativePath causes out-of-date problems on hudson slaves -->
     <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
   </parent>
@@ -14,7 +14,7 @@
   <groupId>org.jbpm</groupId>
   <artifactId>jbpm-form-builder-parent</artifactId>
   <packaging>pom</packaging>
-  <version>5.3.0-SNAPSHOT</version>
+  <version>5.3.0.Final</version>
 
   <name>jBPM Form Builder project</name>
   <description>jBPM: a Business Process Management (BPM) Suite</description>


### PR DESCRIPTION
The error was due to a problem in communication with the REST servlet from guvnor. They changed notations from <packages> to <collection> to refer to a group of assets and the JAXB implementations inside form builder didn't have that included.
